### PR TITLE
Initialise module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Terraform
+**/.terraform/*
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+
+crash.log
+
+*.tfvars
+
+.terraformrc
+terraform.rc

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,8 @@
+formatter: "markdown table"
+settings:
+  anchor: false
+  html: false
+  lockfile: false
+output:
+  file: "Readme.md"
+  mode: "inject"

--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,12 @@
 # spacelift-tailscale Terraform Module
 
-Terraform module that manages [Spacelift][] resources to enable [spacelift-tailscale] to function.
+Terraform module that manages [Spacelift][] resources to enable [caius/spacelift-tailscale][] to function, allowing access from Spacelift to infrastructure inside your [Tailscale][] tailnet.
+
+See [caius/spacelift-tailscale] for more information.
 
 [Spacelift]: https://spacelift.io/
-[spacelift-tailscale]: https://github.com/caius/spacelift-tailscale/
+[caius/spacelift-tailscale]: https://github.com/caius/spacelift-tailscale/
+[Tailscale]: https://tailscale.com/
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/Readme.md
+++ b/Readme.md
@@ -4,3 +4,29 @@ Terraform module that manages [Spacelift][] resources to enable [spacelift-tails
 
 [Spacelift]: https://spacelift.io/
 [spacelift-tailscale]: https://github.com/caius/spacelift-tailscale/
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,10 @@ Terraform module that manages [Spacelift][] resources to enable [spacelift-tails
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| spacelift | >= 1.0 |
 
 ## Providers
 

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,9 @@ Terraform module that manages [Spacelift][] resources to enable [spacelift-tails
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| spacelift | >= 1.0 |
 
 ## Modules
 
@@ -23,11 +25,16 @@ No modules.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [spacelift_context.spacelift-tailscale-runtime](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/context) | resource |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| context\_labels | List of labels for the Spacelift Context. eg. ["autoattach:runtime:spacelift-tailscale"] | `list(string)` | n/a | yes |
+| space\_id | The ID of the Spacelift Space to create the resources inside | `any` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,42 @@
+locals {
+  spacelift_tailscale_setup_commands = [
+    "spacetail up",
+    "trap 'spacetail down' EXIT",
+    "export HTTP_PROXY=http://127.0.0.1:8080 HTTPS_PROXY=http://127.0.0.1:8080",
+  ]
+  spacelift_tailscale_teardown_commands = [
+    "unset HTTP_PROXY HTTPS_PROXY",
+    # Spacelift currently saves env to disk *before* calling the after_apply hook, unlike all the other
+    # phases. Work around that here for now, otherwise it breaks spacelift-worker uploading changes.
+    "sed -e '/HTTP_PROXY=/d' -e /HTTPS_PROXY/d -i /mnt/workspace/.env_hooks_after",
+  ]
+}
+
+variable "context_labels" {
+  description = "List of labels for the Spacelift Context. eg. [\"autoattach:runtime:spacelift-tailscale\"]"
+  type        = list(string)
+}
+
+variable "space_id" {
+  description = "The ID of the Spacelift Space to create the resources inside"
+}
+
+resource "spacelift_context" "spacelift-tailscale-runtime" {
+  name        = "spacelift-tailscale runtime"
+  description = "Configuration for the caius/spacelift-tailscale runtime"
+  space_id    = var.space_id
+
+  labels = var.context_labels
+
+  before_plan = local.spacelift_tailscale_setup_commands
+  after_plan  = local.spacelift_tailscale_teardown_commands
+
+  before_apply = local.spacelift_tailscale_setup_commands
+  after_apply  = local.spacelift_tailscale_teardown_commands
+
+  before_perform = local.spacelift_tailscale_setup_commands
+  after_perform  = local.spacelift_tailscale_teardown_commands
+
+  before_destroy = local.spacelift_tailscale_setup_commands
+  after_destroy  = local.spacelift_tailscale_teardown_commands
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    spacelift = {
+      source  = "spacelift-io/spacelift"
+      version = ">= 1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What?

- [x] Add module structure
- [x] Wire up terraform-docs
- [x] Create context to setup phase hooks for spacetail

## Why?

I manage spacelift stacks with this module internally, but there's nothing proprietary about it so lets make it usable by others too.

We inject `HTTP_PROXY` and `HTTPS_PROXY` in the manner given rather than just setting environment variables on the context because `HTTPS_PROXY` interacts badly with the Spacelift tooling if we leave it set in the environment. See https://github.com/caius/spacelift-tailscale/issues/14 for the back story on that, and also why we have `sed` in there for now.

Spacelift can [autoattach policies to stacks](https://docs.spacelift.io/concepts/policy/#automatically) through a label, which is the suggested way to link this context to a stack.

Closes https://github.com/caius/spacelift-tailscale/issues/15